### PR TITLE
feat: allow version overrides from including projects

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,6 +9,10 @@ buildscript {
   }
 }
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 allprojects {
   repositories {
     google()
@@ -24,12 +28,12 @@ allprojects {
 apply plugin: 'com.android.library'
 
 android {
-  compileSdkVersion 27
-  buildToolsVersion "27.0.2"
+  compileSdkVersion safeExtGet('compileSdkVersion', 27)
+  buildToolsVersion safeExtGet('buildToolsVersion', "27.0.2")
 
   defaultConfig {
-    minSdkVersion 18
-    targetSdkVersion 26
+    minSdkVersion safeExtGet('minSdkVersion', 18)
+    targetSdkVersion safeExtGet('targetSdkVersion', 26)
     versionCode 1
     versionName "1.0"
   }


### PR DESCRIPTION
Adopt standard react-native practice of allowing version overrides for android dependencies

This is needed to fix the react-native-firebase build on the v5.x.x branch