### PR TITLE
feat(windows): jet can run on windows now

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,11 @@
   <a href="https://twitter.com/invertaseio"><img src="https://img.shields.io/twitter/follow/invertaseio.svg?style=social&label=Follow" alt="Follow on Twitter"></a>
 </p>
 
-> **WARNING:** Jet is currently a Proof of Concept, APIs and usage is likely to change by the first release version.
+> **WARNING:** Jet uses a feature of react-native called "Javascript Debugging" which relies on the bundle downloading to a local execution environment and executing there, with the results / requests passed asynchronously via WebSocket to the app running on the device. This method of react-native bundle execution will not be available in some unknown future version of react-native so the premise of the module will change completely. This is being worked on in the @mikehardy/jet-next branch.
 
-> This repo is in development and does not have a full release version yet. v0.1.0 is the latest stable version in it's current form - this works on Android & iOS on React Native ^0.56-59.5 and Detox ^10.0.13.
-----
+> This repo is in development and does not have a full release version yet. v0.4.x is the latest stable version in it's current form - this works on Android & iOS on React Native ^0.56 through ^0.67 and Detox ^10.0.13 through ^18.
+
+---
 
 Jet lets you bring your React Native JS code into NodeJS and test it mock free and native testing code free - ideal for testing React Native modules e2e.
 
@@ -24,22 +25,21 @@ Jet extends upon [`wix/detox`](https://github.com/wix/detox) and by default the 
 
 Detox provides all the functionality you'll need to control your testing app, device and it's UI (if you have one) whilst Jet allows JS code execution in the context of your RN app via Node.js - giving you full access to all the Native api's as you would have inside your app.
 
-----
+---
 
-> Latest supported React Native version: **^0.59.5**
+> Latest supported React Native version: **^0.67.0-rc.2**
 
-> Latest supported Detox version: **^10.0.13**
+> Latest supported Detox version: **^17**
 
-----
+---
 
 ## Features
 
-### ⏩ Test with JavaScript 
+### ⏩ Test with JavaScript
 
 Your test suites and your React Native code run inside NodeJS - making testing your modules with NodeJS testing frameworks (Mocha only currently, to be replaced with Jest) possible.
 
 ![test suite](https://static.invertase.io/assets/jet/tests-1.gif)
-
 
 ### 🐞 Debugging
 
@@ -47,13 +47,11 @@ Supports debugging your test suites and your React Native JS bundle using the st
 
 ![debugging](https://static.invertase.io/assets/jet/debugging.gif)
 
-
 ### 💯 Coverage
 
 Get full code coverage output for your React Native module's JS API using [istanbul/nyc](https://github.com/istanbuljs/nyc) coverage tools.
 
 ![coverage](https://static.invertase.io/assets/jet/coverage.png)
-
 
 ### ☕️ Full Detox API support
 
@@ -61,10 +59,9 @@ Supports the full [Detox API](https://github.com/wix/detox/blob/master/docs/READ
 
 ![detox](https://static.invertase.io/assets/jet/detox.png)
 
-
 ### ✨ Full access to React Native bundle context
 
-Jet gives you full access to the JS context of your React Native app inside NodeJS ⚡️. 
+Jet gives you full access to the JS context of your React Native app inside NodeJS ⚡️.
 
 ## Quick Setup
 
@@ -83,6 +80,7 @@ in your mocha.opts add
 ```
 
 You can update your package.json scripts with a task for packager-jet:
+
 ```
 "packager-jet": "REACT_DEBUGGER='echo nope' react-native start",
 ```
@@ -93,7 +91,7 @@ Before starting your tests launch the packager-jet and afterwards start your det
 
 For now please see the open issues tracking work that needs doing discussions and thoughts on these issues and on Jet will help us mature the project into a useful tool.
 
-----
+---
 
 ## 😎 Projects using Jet
 

--- a/lib/node/index.js
+++ b/lib/node/index.js
@@ -31,6 +31,13 @@ global.jet = module.exports = {
       const modules = Object.entries(rnRequire.getModules());
       for (let i = 0; i < modules.length; i++) {
         const [id, module] = modules[i];
+        let verboseName = module.verboseName;
+
+        // windows verbose names come in with backslashes, replace with forward slashes
+        // so cross-platform lookup (using forward slashes) works on all platforms
+        verboseName = verboseName.split('\\').join('/');
+
+        rnRequireMap[verboseName] = parseInt(id, 10);
         rnRequireMap[module.verboseName] = parseInt(id, 10);
       }
     }


### PR DESCRIPTION
the react-native-firebase e2e suite previously did not work on windows for a couple reasons, one of them was in this dependency

when you call jet.require() from node the pathing in windows is incorrect because of forward slashes vs back slashes

so we just force them one way here as we make our internal lookup table, then the test code itself can use one slash type everywhere